### PR TITLE
Introduce CardHeader component a '<' (previous) button

### DIFF
--- a/wallet/src/components/CardHeader/component.js
+++ b/wallet/src/components/CardHeader/component.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Header, Divider } from 'semantic-ui-react'
+
+const CardHeader = ({ text }) => (
+  <>
+    <Header as="span" style={{ color: 'white' }} floated="left">
+      <h4>&lt;</h4>
+    </Header>
+    <Header as="span" style={{ color: 'white' }} textAlign="center">
+      <h4>{text}</h4>
+    </Header>
+
+    <Divider />
+  </>
+)
+
+export default CardHeader

--- a/wallet/src/components/CardHeader/index.js
+++ b/wallet/src/components/CardHeader/index.js
@@ -1,0 +1,1 @@
+export { default } from './component'

--- a/wallet/src/components/WalletUnlock/component.js
+++ b/wallet/src/components/WalletUnlock/component.js
@@ -1,13 +1,11 @@
 import React from 'react'
-import { Button, Form, Grid, Header, Divider } from 'semantic-ui-react'
+import { Button, Form, Grid } from 'semantic-ui-react'
+
+import CardHeader from '../CardHeader'
 
 const WalletUnlock = () => (
   <>
-    <Header as="h4" style={{ color: 'white' }} textAlign="center">
-      Access your account
-    </Header>
-    <Divider />
-
+    <CardHeader text="Access your account" />
     <Form.Input fluid placeholder="Enter seed" size="large" />
     <Grid columns={2}>
       <Grid.Column verticalAlign="middle" floated="left" textAlign="left">


### PR DESCRIPTION
Just added the visuals for now. Must support clicking on the `<` in future to switch to the right component.

<img width="481" alt="Screenshot 2020-07-18 at 17 13 07" src="https://user-images.githubusercontent.com/3684187/87851822-f4ffed80-c919-11ea-9bd0-d35d47462e90.png">
